### PR TITLE
Extract tests from sub-chapters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,11 @@ use skeptic::{create_test_input, extract_tests_from_string, Test};
 type PreprocessorConfig<'a> = Option<&'a Table>;
 
 fn get_tests_from_book(book: &Book) -> Vec<Test> {
-    let chapters = book.sections.iter().filter_map(|b| match *b {
+    get_tests_from_items(&book.sections)
+}
+
+fn get_tests_from_items(items: &Vec<BookItem>) -> Vec<Test> {
+    let chapters = items.iter().filter_map(|b| match *b {
         BookItem::Chapter(ref ch) => Some(ch),
         _ => None,
     });
@@ -39,7 +43,9 @@ fn get_tests_from_book(book: &Book) -> Vec<Test> {
                 .and_then(|x| x.file_stem())
                 .map(|x| x.to_string_lossy().into_owned())
                 .unwrap_or_else(|| slugify(c.name.clone()).replace('-', "_"));
-            extract_tests_from_string(&c.content, &file_name).0
+            let (mut tests, _) = extract_tests_from_string(&c.content, &file_name);
+            tests.append(&mut get_tests_from_items(&c.sub_items));
+            tests
         })
         .collect::<Vec<_>>()
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -158,13 +158,16 @@ fn nested_book() -> Result<(), Error> {
         .map(|(t, res)| (t.text[0].trim().to_string(), (t, res)))
         .collect::<HashMap<_, _>>();
 
-    assert_eq!(test_list.len(), 3);
+    assert_eq!(test_list.len(), 4);
 
     assert!(test_list.contains_key("// ok top-level"));
     assert!(matches!(test_list["// ok top-level"].1, TestResult::Successful(_)));
 
     assert!(test_list.contains_key("// ok nested"));
     assert!(matches!(test_list["// ok nested"].1, TestResult::Successful(_)));
+
+    assert!(test_list.contains_key("// ok aliased"));
+    assert!(matches!(test_list["// ok aliased"].1, TestResult::Successful(_)));
 
     assert!(test_list.contains_key("// ok double-nested"));
     assert!(matches!(test_list["// ok double-nested"].1, TestResult::Successful(_)));

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -142,3 +142,32 @@ fn long_book() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn nested_book() -> Result<(), Error> {
+    let (tmp_dir, mut book) = get_starting_directories("nested_book")?;
+    let root_tempdir = tmp_dir.path();
+
+    let bookkeeper = BookKeeper::new();
+
+    let table = Table::new();
+    let result = bookkeeper.real_run(Some(&table), root_tempdir.to_path_buf(), &mut book)?;
+
+    let test_list = result
+        .into_iter()
+        .map(|(t, res)| (t.text[0].trim().to_string(), (t, res)))
+        .collect::<HashMap<_, _>>();
+
+    assert_eq!(test_list.len(), 3);
+
+    assert!(test_list.contains_key("// ok top-level"));
+    assert!(matches!(test_list["// ok top-level"].1, TestResult::Successful(_)));
+
+    assert!(test_list.contains_key("// ok nested"));
+    assert!(matches!(test_list["// ok nested"].1, TestResult::Successful(_)));
+
+    assert!(test_list.contains_key("// ok double-nested"));
+    assert!(matches!(test_list["// ok double-nested"].1, TestResult::Successful(_)));
+
+    Ok(())
+}

--- a/test_books/nested_book/.gitignore
+++ b/test_books/nested_book/.gitignore
@@ -1,0 +1,2 @@
+book
+doctest_cache

--- a/test_books/nested_book/book.toml
+++ b/test_books/nested_book/book.toml
@@ -1,0 +1,6 @@
+[book]
+authors = ["Tom Kunc"]
+language = "en"
+multilingual = false
+src = "src"
+title = "Nested Book"

--- a/test_books/nested_book/src/SUMMARY.md
+++ b/test_books/nested_book/src/SUMMARY.md
@@ -3,3 +3,4 @@
 - [Chapter 1](./chapter_1.md)
   - [Chapter 1.1](./chapter_1/chapter_1_1.md)
     - [Chapter 1.1.1](./chapter_1/chapter_1_1/chapter_1_1_1.md)
+  - [Chapter 1](./chapter_1/chapter_1.md)

--- a/test_books/nested_book/src/SUMMARY.md
+++ b/test_books/nested_book/src/SUMMARY.md
@@ -1,0 +1,5 @@
+# Summary
+
+- [Chapter 1](./chapter_1.md)
+  - [Chapter 1.1](./chapter_1/chapter_1_1.md)
+    - [Chapter 1.1.1](./chapter_1/chapter_1_1/chapter_1_1_1.md)

--- a/test_books/nested_book/src/chapter_1.md
+++ b/test_books/nested_book/src/chapter_1.md
@@ -1,0 +1,10 @@
+# Chapter 1
+
+This fragment will compile correctly.
+
+```rust
+// ok top-level
+fn main() {
+    println!("Yeet.");
+}
+```

--- a/test_books/nested_book/src/chapter_1/chapter_1.md
+++ b/test_books/nested_book/src/chapter_1/chapter_1.md
@@ -1,0 +1,10 @@
+# Chapter 1 (Alias)
+
+This fragment will compile correctly.
+
+```rust
+// ok aliased
+fn main() {
+    println!("Throw.");
+}
+```

--- a/test_books/nested_book/src/chapter_1/chapter_1_1.md
+++ b/test_books/nested_book/src/chapter_1/chapter_1_1.md
@@ -1,0 +1,10 @@
+# Chapter 1.1
+
+This fragment will compile correctly.
+
+```rust
+// ok nested
+fn main() {
+    println!("Raise.");
+}
+```

--- a/test_books/nested_book/src/chapter_1/chapter_1_1/chapter_1_1_1.md
+++ b/test_books/nested_book/src/chapter_1/chapter_1_1/chapter_1_1_1.md
@@ -1,0 +1,10 @@
+# Chapter 1.1.1
+
+This fragment will compile correctly.
+
+```rust
+// ok double-nested
+fn main() {
+    println!("Fold.");
+}
+```


### PR DESCRIPTION
I've started looking into using mdbook-keeper with [Comprehensive Rust 🦀](https://github.com/google/comprehensive-rust), but apparently tests in sub-chapters aren't found. This adds a test-case demonstrating the problem and refactors `get_tests_from_book` to recursively discover tests.