### PR TITLE
Add support for compile_fail

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,6 +213,10 @@ fn print_results(results: &HashMap<Test, TestResult>) {
             eprint!(" - Test: {} ", test.name);
         }
         let output = match test_result {
+            TestResult::CompileFailed(output) if test.compile_fail => {
+                eprintln!("{}", "(Failed to compile as expected)".green());
+                output
+            }
             TestResult::CompileFailed(output) => {
                 eprintln!("{}", "(Failed to compile)".red());
                 output

--- a/src/run_tests.rs
+++ b/src/run_tests.rs
@@ -33,6 +33,7 @@ impl TestResult {
     /// stay cached unless they pass.
     pub fn met_test_expectations(&self, test: &Test) -> bool {
         match self {
+            TestResult::CompileFailed(_) if !test.compile_fail => true,
             TestResult::Successful(_) if !test.should_panic => true,
             TestResult::RunFailed(_) if test.should_panic => true,
             TestResult::Cached => true,

--- a/src/skeptic.rs
+++ b/src/skeptic.rs
@@ -72,6 +72,7 @@ pub fn extract_tests_from_string(s: &str, file_stem: &str) -> (Vec<Test>, Option
                         tests.push(Test {
                             name,
                             ignore: code_block_info.ignore,
+                            compile_fail: code_block_info.compile_fail,
                             no_run: code_block_info.no_run,
                             should_panic: code_block_info.should_panic,
                             template: code_block_info.template,
@@ -113,6 +114,7 @@ pub fn parse_code_block_info(info: &str) -> CodeBlockInfo {
     let mut info = CodeBlockInfo {
         is_rust: false,
         should_panic: false,
+        compile_fail: false,
         ignore: false,
         no_run: false,
         is_old_template: false,
@@ -133,6 +135,10 @@ pub fn parse_code_block_info(info: &str) -> CodeBlockInfo {
             "ignore" => {
                 info.ignore = true;
                 seen_rust_tags = true
+            }
+            "compile_fail" => {
+                info.compile_fail = true;
+                seen_rust_tags = true;
             }
             "no_run" => {
                 info.no_run = true;
@@ -160,6 +166,7 @@ pub struct CodeBlockInfo {
     is_rust: bool,
     should_panic: bool,
     ignore: bool,
+    compile_fail: bool,
     no_run: bool,
     is_old_template: bool,
     template: Option<String>,
@@ -170,6 +177,7 @@ pub struct Test {
     pub(crate) name: String,
     pub(crate) text: Vec<String>,
     pub(crate) ignore: bool,
+    pub(crate) compile_fail: bool,
     pub(crate) no_run: bool,
     pub(crate) should_panic: bool,
     pub(crate) template: Option<String>,

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -72,7 +72,7 @@ fn short_book() -> Result<(), Error> {
         .map(|(t, res)| (t.text[0].trim().to_string(), (t, res)))
         .collect::<HashMap<_, _>>();
 
-    assert_eq!(test_list.len(), 5);
+    assert_eq!(test_list.len(), 6);
 
     assert!(test_list.contains_key("// compile-error"));
     assert!(matches!(
@@ -96,6 +96,12 @@ fn short_book() -> Result<(), Error> {
     assert!(matches!(
         test_list["// panic-ok"].1,
         TestResult::RunFailed(_)
+    ));
+
+    assert!(test_list.contains_key("// compile-fail"));
+    assert!(matches!(
+        test_list["// compile-fail"].1,
+        TestResult::CompileFailed(_)
     ));
 
     Ok(())

--- a/test_books/short_book/src/chapter_1.md
+++ b/test_books/short_book/src/chapter_1.md
@@ -57,3 +57,12 @@ fn main() {
     panic!(":(")
 }
 ```
+
+This won't compile
+
+```rust,compile_fail
+// compile-fail
+fn main() {
+    asdf
+}
+```


### PR DESCRIPTION
 [Comprehensive Rust 🦀](https://github.com/google/comprehensive-rust) uses `compile_fail` [code block attribute](https://rust-lang.github.io/mdBook/format/mdbook.html#rust-code-block-attributes) quite a bit. Although some of these don't compile due to missing dependencies, others are intentionally invalid.