### PR TITLE
Use --crate_type=lib with no_run

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ fn get_tests_from_book(book: &Book) -> Vec<Test> {
     get_tests_from_items(&book.sections)
 }
 
-fn get_tests_from_items(items: &Vec<BookItem>) -> Vec<Test> {
+fn get_tests_from_items(items: &[BookItem]) -> Vec<Test> {
     let chapters = items.iter().filter_map(|b| match *b {
         BookItem::Chapter(ref ch) => Some(ch),
         _ => None,

--- a/src/run_tests.rs
+++ b/src/run_tests.rs
@@ -70,8 +70,12 @@ pub fn handle_test(
             "--color=always"
         } else {
             "--color=never"
-        })
-        .arg("--crate-type=bin");
+        });
+
+    match compile_type {
+        CompileType::Full => cmd.arg("--crate-type=bin"),
+        CompileType::Check => cmd.arg("--crate-type=lib"),
+    };
 
     if let Some(manifest_dir) = manifest_dir {
         // OK, here's where a bunch of magic happens using assumptions

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -83,7 +83,7 @@ fn short_book() -> Result<(), Error> {
     assert!(test_list.contains_key("// no-run"));
     assert!(matches!(
         test_list["// no-run"].1,
-        TestResult::CompileFailed(_)
+        TestResult::Successful(_)
     ));
 
     assert!(test_list.contains_key("// ok"));

--- a/test_books/short_book/src/chapter_1.md
+++ b/test_books/short_book/src/chapter_1.md
@@ -10,14 +10,11 @@ fn main() {
 }
 ```
 
-This fragment would break, but won't! Thanks `no_run`
+This fragment would break (missing `main()`), but won't! Thanks `no_run`
 
 ```rust,no_run
 // no-run
-fn main() {
-    println!("Another example!");
-    asdf
-}
+struct Foo;
 ```
 
 This fragment will compile correctly.


### PR DESCRIPTION
With an example that has no executable code, e.g.
```rust
struct Foo;
```

There are two ways to cope with this (that I've thought of):
* Add `# fn main() {}` (i.e. a `main()` that's hidden by default)
* Use `no_run` *and* build with `--crate-type=lib`

This PR implements `--crate-type=lib` because it feels cleaner to me. This works fine even in the presence of `main()`. I haven't thought of a downside.
