### PR TITLE
Use the full path as the test prefix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,6 @@ fn get_tests_from_items(items: &Vec<BookItem>) -> Vec<Test> {
             let file_name = c
                 .path
                 .as_ref()
-                .and_then(|x| x.file_stem())
                 .map(|x| x.to_string_lossy().into_owned())
                 .unwrap_or_else(|| slugify(c.name.clone()).replace('-', "_"));
             let (mut tests, _) = extract_tests_from_string(&c.content, &file_name);


### PR DESCRIPTION
For some context, [Comprehensive Rust 🦀](https://github.com/google/comprehensive-rust) has ~260 chapters in ~50 directories (~25 top-level, ~25 nested). To help locate the relevant file, this PR uses the whole path as the prefix, which looks like:
```
 - Test: pattern-matching.md_sect_pattern_matching_line_8 (Passed)
 - Test: basic-syntax/string-slices.md_sect_vs_line_5 (Passed)
 - Test: exercises/day-1/solutions-morning.md_sect_arrays_and_loops_line_86 (Passed)
 - Test: exercises/day-3/solutions-morning.md_sect_a_simple_gui_library_line_7 (Passed)
```

For comparison, the output without this change looks like:
```
 - Test: pattern-matching_sect_pattern_matching_line_8 (Passed)
 - Test: string-slices_sect_vs_line_5 (Passed)
 - Test: solutions-morning_sect_arrays_and_loops_line_86 (Passed)
 - Test: solutions-morning_sect_a_simple_gui_library_line_7 (Passed)
```

I was going to 'escape' the test name in some way, but it's not obviously necessary or beneficial. Related: I originally removed ".md" from the end, to avoid behavior changes. However, I think it's easer to understand with the extension and isn't much noisier.

I'm fine with some form of 'escaping', if desired. I mostly want the directories to help locate the file.