### PR TITLE
compile_fail shouldn't run successfully

### DIFF
--- a/src/run_tests.rs
+++ b/src/run_tests.rs
@@ -34,7 +34,7 @@ impl TestResult {
     pub fn met_test_expectations(&self, test: &Test) -> bool {
         match self {
             TestResult::CompileFailed(_) if test.compile_fail => true,
-            TestResult::Successful(_) if !test.should_panic => true,
+            TestResult::Successful(_) if !test.should_panic && !test.compile_fail => true,
             TestResult::RunFailed(_) if test.should_panic => true,
             TestResult::Cached => true,
             _ => false,


### PR DESCRIPTION
This follows up on @mgeisler's comment on #3. While working on this, I realized there's some wrinkles with "weird" test configs that this doesn't address. Validation seems desirable, but there are some details I'm unsure of. I filed #7 for the moment.