### PR TITLE
compile with debug symbols

### DIFF
--- a/src/run_tests.rs
+++ b/src/run_tests.rs
@@ -70,7 +70,8 @@ pub fn handle_test(
             "--color=always"
         } else {
             "--color=never"
-        });
+        })
+        .arg("-g");
 
     match compile_type {
         CompileType::Full => cmd.arg("--crate-type=bin"),


### PR DESCRIPTION
I ran into a case where I wanted to run one of my code snippets through a debugger and noticed that you are not compiling with debug symbols, even though you are explicitly linking to debug compiles of the dependencies. This PR adds "-g" to `rustc` call in `handle_test`.